### PR TITLE
Forever

### DIFF
--- a/.foreverignore
+++ b/.foreverignore
@@ -1,0 +1,7 @@
+config/*
+log/*
+script/*
+.gitignore
+LICENCE
+package.json
+README.md

--- a/README.md
+++ b/README.md
@@ -18,19 +18,34 @@ to control your Harmony Hub, so your control is just a simple HTTP request away.
 ## Setup
 
     script/bootstrap
-    script/server
+
+## Running It
+Get up and running immediatly with `script/server`.
 
 Harmony API will run on port `8282` by default. Use the `PORT` environment
 variable to use your own port.
 
+### Forever
+harmony-api has support for [Forever](https://github.com/foreverjs/forever). It uses
+`launchd` on OS X to kick it off so that it starts on boot. There is no `init.d`
+other Linux support of this type. Pull requests would be welcome for this though.
+
+### Development
+You can simply run it by calling `script/server`. This will run it in development
+mode with logging to standard out.
+
+### Install as Service on OS X
+
+    script/install
+
 ## Logging
 
-Harmony API logs all of its requests. In `production`, it logs to a file at `log/production.log`.
+Harmony API logs all of its requests. In `production`, it logs to a file at `log/logs.log`.
 In `development` mode, it just logs to stdout.
 
 ## Development
 
-Launch the app via `npm run start` to run it in the development environment.
+Launch the app via `script/server` to run it in the development environment.
 
 ## Docs
 

--- a/app.js
+++ b/app.js
@@ -12,20 +12,11 @@ var harmonyActivitiesCache = {}
 var harmonyActivityUpdateInterval = 1*60*1000 // 1 minute
 var harmonyActivityUpdateTimer
 
-var env = process.env.NODE_ENV || 'development';
-var logDirectory = __dirname + '/log'
-
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))
 
 var logFormat = "'[:date[iso]] - :remote-addr - :method :url :status :response-time ms - :res[content-length]b'"
-if ('development' == env){
-  app.use(morgan(logFormat))
-}else if ('production' == env){
-  fs.existsSync(logDirectory) || fs.mkdirSync(logDirectory)
-  var accessLogStream = fs.createWriteStream(logDirectory + '/' + env + '.log', {flags: 'a'})
-  app.use(morgan(logFormat, {stream: accessLogStream}))
-}
+app.use(morgan(logFormat))
 
 // Middleware
 // Check to make sure we have a harmonyHubClient to connect to

--- a/config/forever/development.json
+++ b/config/forever/development.json
@@ -1,0 +1,5 @@
+{
+  "append": true,
+  "watch": true,
+  "script": "app.js"
+}

--- a/config/forever/production.json
+++ b/config/forever/production.json
@@ -2,6 +2,6 @@
   "uid": "harmony-api",
   "append": true,
   "script": "app.js",
-  "outFile": "log/out.log",
+  "outFile": "log/logs.log",
   "errFile": "log/error.log"
 }

--- a/config/forever/production.json
+++ b/config/forever/production.json
@@ -1,0 +1,7 @@
+{
+  "uid": "harmony-api",
+  "append": true,
+  "script": "app.js",
+  "outFile": "log/out.log",
+  "errFile": "log/error.log"
+}

--- a/config/org.harmony-api.plist
+++ b/config/org.harmony-api.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>org.harmony-api</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin/:$PATH</string>
+      <key>NODE_ENV</key>
+      <string>production</string>
+    </dict>
+
+    <key>Program</key>
+    <string>script/server</string>
+
+    <key>AbandonProcessGroup</key>
+    <false/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/jmaddox/source/harmony-api</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/jmaddox/Library/Logs/harmony-api.log</string>
+
+    <key>StandardOutPath</key>
+    <string>/Users/jmaddox/Library/Logs/harmony-api.log</string>
+
+  </dict>
+</plist>

--- a/config/org.harmony-api.plist
+++ b/config/org.harmony-api.plist
@@ -29,13 +29,13 @@
     </dict>
 
     <key>WorkingDirectory</key>
-    <string>/Users/jmaddox/source/harmony-api</string>
+    <string>%PATH%</string>
 
     <key>StandardErrorPath</key>
-    <string>/Users/jmaddox/Library/Logs/harmony-api.log</string>
+    <string>/Users/%USER%/Library/Logs/harmony-api.log</string>
 
     <key>StandardOutPath</key>
-    <string>/Users/jmaddox/Library/Logs/harmony-api.log</string>
+    <string>/Users/%USER%/Library/Logs/harmony-api.log</string>
 
   </dict>
 </plist>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "morgan": "^1.6.1",
     "body-parser": "^1.12.4",
     "harmonyhubjs-client": "^1.1.4",
-    "harmonyhubjs-discover": "git@github.com:swissmanu/harmonyhubjs-discover.git"
+    "harmonyhubjs-discover": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmony-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple server providing a RESTful service for controlling a Harmony Hub.",
   "scripts": {
     "start": "node app.js"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,3 +1,19 @@
 #!/bin/sh
 
+set -e
+
+if ! test $(which forever)
+then
+  echo
+  echo "!!!!"
+  echo "You don't have forever installed. You need to install it first."
+  echo
+  echo "Just install it with this command: "
+  echo 'sudo npm install forever -g'
+  echo
+  exit 1
+fi
+
 npm install
+
+echo "Finished setting up harmony-api! run it with script/server or install it with script/install."

--- a/script/install
+++ b/script/install
@@ -2,6 +2,8 @@
 
 set -e
 
+echo "Installing harmony-api..."
+
 APP_PATH=`pwd`
 USER_NAME=`whoami`
 

--- a/script/install
+++ b/script/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cp config/org.harmony-api.plist ~/Library/LaunchAgents/org.harmony-api.plist
+launchctl load -w -F ~/Library/LaunchAgents/org.harmony-api.plist

--- a/script/install
+++ b/script/install
@@ -1,4 +1,13 @@
 #!/bin/sh
 
+set -e
+
+APP_PATH=`pwd`
+USER_NAME=`whoami`
+
 cp config/org.harmony-api.plist ~/Library/LaunchAgents/org.harmony-api.plist
+
+sed -i '' -e "s#%USER%#$USER_NAME#g" ~/Library/LaunchAgents/org.harmony-api.plist
+sed -i '' -e "s#%PATH%#$APP_PATH#g" ~/Library/LaunchAgents/org.harmony-api.plist
+
 launchctl load -w -F ~/Library/LaunchAgents/org.harmony-api.plist

--- a/script/restart
+++ b/script/restart
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+script/uninstall
+script/install

--- a/script/server
+++ b/script/server
@@ -1,6 +1,10 @@
 #!/bin/sh
 
 test -z "$NODE_ENV" &&
-  export NODE_ENV='production'
+  export NODE_ENV='development'
 
-npm run start
+if [ "$NODE_ENV" = "development" ]; then
+  /usr/local/bin/forever -f config/forever/development.json
+else
+  /usr/local/bin/forever start config/forever/production.json
+fi

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+forever stop harmony-api
+launchctl unload ~/Library/LaunchAgents/org.harmony-api.plist
+rm ~/Library/LaunchAgents/org.harmony-api.plist

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-forever stop harmony-api
 echo "Uninstalling harmony-api..."
+forever stop harmony-api > /dev/null 2>&1
 launchctl unload ~/Library/LaunchAgents/org.harmony-api.plist
 rm ~/Library/LaunchAgents/org.harmony-api.plist

--- a/script/uninstall
+++ b/script/uninstall
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 forever stop harmony-api
+echo "Uninstalling harmony-api..."
 launchctl unload ~/Library/LaunchAgents/org.harmony-api.plist
 rm ~/Library/LaunchAgents/org.harmony-api.plist

--- a/script/upgrade
+++ b/script/upgrade
@@ -1,0 +1,8 @@
+#!/bin/sh
+echo "Updating from GitHub..."
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git pull origin $BRANCH
+
+npm update
+
+script/restart


### PR DESCRIPTION
This adds support for Forever. This keeps the app launched.

All logging goes to standard out now and logs are written by Forever.

This also adds a way to install the app as a service on OS X via `launchd`.

Just run `script/install` and you'll be off to the races.
