### PR TITLE
MQTT API

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ harmony-api publishes topics with the namespace of: `harmony-api`.
 is changed or the hub is turned off via the API. Activity name is parameterized
 and underscored. IE, `watch_tv`.
 
-## API Docs
+## HTTP API Docs
 
 This is a quick overview of the service. Read [app.js](app.js) if you need more
 info.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Activity set up in your Harmony Hub.
 ```json
 {
   "id": "15233552",
+  "slug": "watch_tv",
   "label": "Watch TV",
   "isAVActivity": true
 }
@@ -106,6 +107,7 @@ The Status resource returns the current state of your Harmony Hub.
   "off": false,
   "current_activity": {
     "id": "15233552",
+    "slug": "watch_tv",
     "label": "Watch TV",
     "isAVActivity": true
   }
@@ -126,7 +128,7 @@ These are the endpoints you can hit to do things.
   Use these endpoints to control your devices through your Harmony Hub.
 
     PUT /off => NowPlayingResource => {message: "ok"}
-    POST /start_activity?activity_name=Watch%20TV => {message: "ok"}
+    POST /start_activity?activity=watch_tv => {message: "ok"}
 
 ## To Do
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In `development` mode, it just logs to stdout.
 
 Launch the app via `script/server` to run it in the development environment.
 
-## MQTT
+## MQTT Docs
 
 harmony-api can report its state changes to your MQTT broker. Just edit your
 config file in `config/config.json` to add your MQTT host.
@@ -68,9 +68,6 @@ harmony-api publishes topics with the namespace of: `harmony-api`.
 
 ### Topics
 
-`harmony-api/state`, `$ACTIVITY_NAME` - This is published whenever the activity
-is changed or the hub is turned off via the API. Activity name is parameterized
-and underscored. IE, `watch_tv`.
 
 ## HTTP API Docs
 
@@ -92,7 +89,7 @@ Activity set up in your Harmony Hub.
 ```json
 {
   "id": "15233552",
-  "slug": "watch_tv",
+  "slug": "watch-tv",
   "label": "Watch TV",
   "isAVActivity": true
 }
@@ -107,7 +104,7 @@ The Status resource returns the current state of your Harmony Hub.
   "off": false,
   "current_activity": {
     "id": "15233552",
-    "slug": "watch_tv",
+    "slug": "watch-tv",
     "label": "Watch TV",
     "isAVActivity": true
   }
@@ -128,7 +125,7 @@ These are the endpoints you can hit to do things.
   Use these endpoints to control your devices through your Harmony Hub.
 
     PUT /off => NowPlayingResource => {message: "ok"}
-    POST /start_activity?activity=watch_tv => {message: "ok"}
+    POST /start_activity?activity=watch-tv => {message: "ok"}
 
 ## To Do
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Harmony API!!
 
-Harmony API is a simple REST server allowing you to query/control a local [Harmony
-Home Hub](http://myharmony.com/products/detail/home-hub/). Yes, there are libraries
-that can already do this (this server uses one :wink:).
+Harmony API is a simple server allowing you to query/control a local [Harmony
+Home Hub](http://myharmony.com/products/detail/home-hub/) over HTTP or MQTT.
 
-But not all languages have Harmony Hub clients. Also, some times these clients are
-complicated to add to your other projects. Harmony API gives you a simple REST server
-to control your Harmony Hub, so your control is just a simple HTTP request away.
+With HTTP, you can simply turn your devices on and off and check their status
+with simple HTTP requests from almost any other project.
+
+With MQTT, you can easily monitor the state of your devices as well as switch
+the current activity of your whole hub. This makes it super easy to integrate
+into your existing home automation setup.
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,46 @@ config file in `config/config.json` to add your MQTT host.
 
 harmony-api publishes topics with the namespace of: `harmony-api`.
 
-### Topics
+### State Topics
+
+When the state changes on your harmony hub, state topics will be immediately
+broadcasted over your broker. There's quite a few topics that are broadcasted.
+
+Here's a list:
+
+#### Current State
+
+This topic describes the current power state. Message is `on` or `off`.
+
+`harmony-api/state` `on`
+
+#### Current Activity
+
+This topic describes what the current activity of the hub is. The message is
+the slug of an activity name.
+
+`harmony-api/current_activity` `watch-tv`
+
+#### Activity States
+
+These topics describe the state of each activity that the hub has. The message
+is `on` or `off`. There will a topic for every activity on your hub.
+
+`harmony-api/activities/watch-tv/state` `off`  
+`harmony-api/activities/watch-apple-tv/state` `on`  
+`harmony-api/activities/play-xbox-one/state` `off`  
+
+
+### Command Topics
+
+You can also command harmony-api to change activities by publishing topics.
+harmony-api listens to this topic and will change to the activity when it sees
+it.
+
+Just provide the slug of the activity you want to switch to and `on` as the
+message. Any use of this topic with the message `off` will turn everything off.
+
+`harmony-api/activities/watch-tv/command` `on`  
 
 
 ## HTTP API Docs

--- a/app.js
+++ b/app.js
@@ -175,18 +175,6 @@ function currentActivity(){
   return harmonyState.current_activity
 }
 
-function activityByName(activityName){
-  var activity
-  cachedHarmonyActivities().some(function(a) {
-    if(a.label === activityName) {
-      activity = a
-      return true
-    }
-  })
-
-  return activity
-}
-
 function activityBySlug(activitySlug){
   var activity
   cachedHarmonyActivities().some(function(a) {

--- a/app.js
+++ b/app.js
@@ -179,6 +179,18 @@ function activityByName(activityName){
   return activity
 }
 
+function activityBySlug(activitySlug){
+  var activity
+  cachedHarmonyActivities().some(function(a) {
+    if(a.slug === activitySlug) {
+      activity = a
+      return true
+    }
+  })
+
+  return activity
+}
+
 function off(){
   if (!harmonyHubClient) { return }
 

--- a/app.js
+++ b/app.js
@@ -71,11 +71,11 @@ if (config['hub_ip']) {
 // mqtt api
 
 mqttClient.on('connect', function () {
-  mqttClient.subscribe(TOPIC_NAMESPACE + '/command/+')
+  mqttClient.subscribe(TOPIC_NAMESPACE + '/activities/+/command')
 });
 
 mqttClient.on('message', function (topic, message) {
-  var commandPattern = new RegExp(/command\/(.*)/);
+  var commandPattern = new RegExp(/activities\/(.*)\/command/);
   var commandMatches = topic.match(commandPattern);
 
   if (commandMatches) {

--- a/app.js
+++ b/app.js
@@ -243,7 +243,7 @@ app.put('/off', function(req, res){
 })
 
 app.post('/start_activity', function(req, res){
-  activity = activityByName(req.body.activity_name)
+  activity = activityBySlug(req.body.activity)
 
   if (activity) {
     startActivity(activity.id)

--- a/app.js
+++ b/app.js
@@ -79,11 +79,11 @@ mqttClient.on('message', function (topic, message) {
   var commandMatches = topic.match(commandPattern);
 
   if (commandMatches) {
-    var action = commandMatches[1]
+    var activitySlug = commandMatches[1]
     var state = message.toString()
 
-    if (action === 'start_activity') {
-      activity = activityByName(state)
+    activity = activityBySlug(activitySlug)
+    if (!activity) { return }
 
       if (activity) {
         startActivity(activity.id)

--- a/app.js
+++ b/app.js
@@ -116,7 +116,7 @@ function updateActivities(){
   harmonyHubClient.getActivities().then(function(activities){
     foundActivities = {}
     activities.some(function(activity) {
-      foundActivities[activity.id] = {id: activity.id, slug: parameterize(activity.label).replace(/-/g, '_'), label:activity.label, isAVActivity: activity.isAVActivity}
+      foundActivities[activity.id] = {id: activity.id, slug: parameterize(activity.label), label:activity.label, isAVActivity: activity.isAVActivity}
     })
 
     harmonyActivitiesCache = foundActivities

--- a/app.js
+++ b/app.js
@@ -150,6 +150,14 @@ function activityByName(activityName){
   return activity
 }
 
+function off(){
+  if (!harmonyHubClient) { return }
+
+  harmonyHubClient.turnOff().then(function(){
+    updateState()
+  })
+}
+
 function publish(topic, message, options){
   topic = TOPIC_NAMESPACE + "/" + topic
   mqttClient.publish(topic, message, options);
@@ -172,9 +180,7 @@ app.get('/status', function(req, res){
 })
 
 app.put('/off', function(req, res){
-  harmonyHubClient.turnOff().then(function(){
-    updateState()
-  })
+  off()
 
   res.json({message: "ok"})
 })

--- a/app.js
+++ b/app.js
@@ -74,6 +74,29 @@ mqttClient.on('connect', function () {
   mqttClient.subscribe('harmony/command/+')
 });
 
+mqttClient.on('message', function (topic, message) {
+  var commandPattern = new RegExp(/command\/(.*)/);
+  var commandMatches = topic.match(commandPattern);
+
+  if (commandMatches) {
+    var action = commandMatches[1]
+    var state = message.toString()
+
+    if (action === 'start_activity') {
+      activity = activityByName(state)
+
+      if (activity) {
+        startActivity(activity.id)
+      }
+    } else if (action === 'off') {
+      off()
+    }
+
+  }
+
+});
+
+
 function startProcessing(harmonyClient){
   harmonyHubClient = harmonyClient
 

--- a/app.js
+++ b/app.js
@@ -118,7 +118,7 @@ function updateActivities(){
   harmonyHubClient.getActivities().then(function(activities){
     foundActivities = {}
     activities.some(function(activity) {
-      foundActivities[activity.id] = {id: activity.id, label: activity.label, isAVActivity: activity.isAVActivity}
+      foundActivities[activity.id] = {id: activity.id, slug: parameterize(activity.label).replace(/-/g, '_'), label:activity.label, isAVActivity: activity.isAVActivity}
     })
 
     harmonyActivitiesCache = foundActivities

--- a/app.js
+++ b/app.js
@@ -164,7 +164,7 @@ function cachedHarmonyActivities(){
 function currentActivity(){
   if (!harmonyHubClient || !harmonyState) { return null}
 
-  return harmonyState.off ? 'off' : harmonyState.current_activity.label
+  return harmonyState.current_activity
 }
 
 function activityByName(activityName){

--- a/app.js
+++ b/app.js
@@ -139,7 +139,7 @@ function updateState(){
     if (activityId != -1 && activity) {
       data = {off: false, current_activity: activity}
     }else{
-      data = {off: true}
+      data = {off: true, current_activity: activity}
     }
 
     harmonyState = data

--- a/app.js
+++ b/app.js
@@ -68,6 +68,12 @@ if (config['hub_ip']) {
   discover.start()
 }
 
+// mqtt api
+
+mqttClient.on('connect', function () {
+  mqttClient.subscribe('harmony/command/+')
+});
+
 function startProcessing(harmonyClient){
   harmonyHubClient = harmonyClient
 

--- a/app.js
+++ b/app.js
@@ -158,6 +158,14 @@ function off(){
   })
 }
 
+function startActivity(activityId){
+  if (!harmonyHubClient) { return }
+
+  harmonyHubClient.startActivity(activityId).then(function(){
+    updateState()
+  })
+}
+
 function publish(topic, message, options){
   topic = TOPIC_NAMESPACE + "/" + topic
   mqttClient.publish(topic, message, options);
@@ -189,9 +197,7 @@ app.post('/start_activity', function(req, res){
   activity = activityByName(req.body.activity_name)
 
   if (activity) {
-    harmonyHubClient.startActivity(activity.id).then(function(){
-      updateState()
-    })
+    startActivity(activity.id)
 
     res.json({message: "ok"})
   }else{

--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ if (config['hub_ip']) {
 // mqtt api
 
 mqttClient.on('connect', function () {
-  mqttClient.subscribe('harmony/command/+')
+  mqttClient.subscribe(TOPIC_NAMESPACE + '/command/+')
 });
 
 mqttClient.on('message', function (topic, message) {

--- a/app.js
+++ b/app.js
@@ -161,7 +161,7 @@ function cachedHarmonyActivities(){
   })
 }
 
-function currentActivityName(){
+function currentActivity(){
   if (!harmonyHubClient || !harmonyState) { return null}
 
   return harmonyState.off ? 'off' : harmonyState.current_activity.label

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harmony-api",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "description": "A simple server providing a RESTful service for controlling a Harmony Hub.",
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
This adds new state topics to describe current activities and state as well as command topics to allow control over MQTT.

Command topics allow you to set which activity is currently in use. Simply publish the appropriate topic to your MQTT broker and harmony-api will change the activity accordingly. This allows you to go 100% mqtt and not worry about any HTTP requests. This is very useful in a home automation setting.

This also 
## Changes

The HTTP API now uses slugs instead of full names when requesting to change an activity. It also uses the param name `activity` instead of `activity_name`.

```
POST /start_activity?activity=watch-tv => {message: "ok"}
```
## New MQTT Topics

Here's a list of what the new topics look like (ripped from the README)
### State Topics

When the state changes on your harmony hub, state topics will be immediately
broadcasted over your broker. There's quite a few topics that are broadcasted.

Here's a list:
#### Current State

This topic describes the current power state. Message is `on` or `off`.

`harmony-api/state` `on`
#### Current Activity

This topic describes what the current activity of the hub is. The message is
the slug of an activity name.

`harmony-api/current_activity` `watch-tv`
#### Activity States

These topics describe the state of each activity that the hub has. The message
is `on` or `off`. There will a topic for every activity on your hub.

`harmony-api/activities/watch-tv/state` `off`  
`harmony-api/activities/watch-apple-tv/state` `on`  
`harmony-api/activities/play-xbox-one/state` `off`  
### Command Topics

You can also command harmony-api to change activities by publishing topics.
harmony-api listens to this topic and will change to the activity when it sees
it.

Just provide the slug of the activity you want to switch to and `on` as the
message. Any use of this topic with the message `off` will turn everything off.

`harmony-api/activities/watch-tv/command` `on`  
