### PR TITLE
MQTT options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ broker's host to connect to it.
 
 ```json
 {
-  "mqtt_host": "192.168.1.106"
+  "mqtt_host": "192.168.1.106",
   "mqtt_options": {
       "port": 1883,
       "username": "someuser",

--- a/README.md
+++ b/README.md
@@ -30,8 +30,17 @@ broker's host to connect to it.
 ```json
 {
   "mqtt_host": "192.168.1.106"
+  "mqtt_options": {
+      "port": 1883,
+      "username": "someuser",
+      "password": "somepassword",
+      "rejectUnauthorized": false
+  }
 }
 ```
+
+`mqtt_options` is optional, see the [mqtt](https://github.com/mqttjs/MQTT.js#connect) project for
+allowed host and options values.
 
 ## Running It
 Get up and running immediately with `script/server`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ broker's host to connect to it.
       "username": "someuser",
       "password": "somepassword",
       "rejectUnauthorized": false
-  }
+  },
+  "topic_namespace": "home/harmony"
 }
 ```
 
@@ -75,7 +76,8 @@ Launch the app via `script/server` to run it in the development environment.
 harmony-api can report its state changes to your MQTT broker. Just edit your
 config file in `config/config.json` to add your MQTT host.
 
-harmony-api publishes topics with the namespace of: `harmony-api`.
+By default harmony-api publishes topics with the namespace of: `harmony-api`. This can be overriden
+by setting `topic_namespace` in your config file.
 
 ### State Topics
 

--- a/app.js
+++ b/app.js
@@ -21,8 +21,9 @@ var harmonyState
 var harmonyStateUpdateInterval = 5*1000 // 5 seconds
 var harmonyStateUpdateTimer
 
-var mqttClient = mqtt.connect(config.mqtt_host);
-var TOPIC_NAMESPACE = "harmony-api"
+var mqttClient = config.hasOwnProperty("mqtt_options") ?
+    mqtt.connect(config.mqtt_host, config.mqtt_options) :
+    mqtt.connect(config.mqtt_host);
 
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))

--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ var harmonyStateUpdateTimer
 var mqttClient = config.hasOwnProperty("mqtt_options") ?
     mqtt.connect(config.mqtt_host, config.mqtt_options) :
     mqtt.connect(config.mqtt_host);
+var TOPIC_NAMESPACE = config.topic_namespace || "harmony-api";
 
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,3 +1,9 @@
 {
-  "mqtt_host": "http://127.0.0.1"
+  "mqtt_host": "http://127.0.0.1",
+  "mqtt_options": {
+      "port": 1883,
+      "username": "someuser",
+      "password": "somepassword",
+      "rejectUnauthorized": false
+  }
 }


### PR DESCRIPTION
Adds the ability to specify MQTT options, effectively allowing you to connect to an MQTT server with TLS and username/password (fixing #9). Also add the ability to specify a MQTT namespace in the config file.
