### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:argon
+
+# Create app directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install app dependencies
+COPY package.json /usr/src/app
+RUN npm install
+
+COPY . /usr/src/app
+
+EXPOSE 8282
+CMD [ "npm", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ RUN npm install
 
 COPY . /usr/src/app
 
+ENV CONFIG_DIR /config
+
 EXPOSE 8282
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ mode with logging to standard out.
 
     script/install
 
+### Docker
+Installation with Docker is straightforward. Adjust the following command so that
+`/path/to/your/config` points to the folder where your want to store your config and run it:
+
+    $ docker run --name="harmony-api" -v /path/to/your/config:/usr/src/app/config \
+        -p 8282:8282 -d jawilson/harmony-api
+
+This will launch Harmony API and serve the web interface from port 8282 on your Docker host. Hub
+discovery requires host networking (`--net=host`). However, you can specify your Harmony Hub IP
+address in `config.json` as `hub_ip`.
+
 ## Logging
 
 Harmony API logs all of its requests. In `production`, it logs to a file at `log/logs.log`.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ mode with logging to standard out.
 Installation with Docker is straightforward. Adjust the following command so that
 `/path/to/your/config` points to the folder where your want to store your config and run it:
 
-    $ docker run --name="harmony-api" -v /path/to/your/config:/usr/src/app/config \
+    $ docker run --name="harmony-api" -v /path/to/your/config:/config \
         -p 8282:8282 -d jawilson/harmony-api
 
 This will launch Harmony API and serve the web interface from port 8282 on your Docker host. Hub

--- a/app.js
+++ b/app.js
@@ -7,7 +7,8 @@ var morgan = require('morgan')
 var bodyParser = require('body-parser')
 var parameterize = require('parameterize');
 
-var config = require('./config/config.json');
+var config_dir = process.env.CONFIG_DIR || './config'
+var config = require(config_dir + '/config.json');
 
 var harmonyHubDiscover = require('harmonyhubjs-discover')
 var harmony = require('harmonyhubjs-client')


### PR DESCRIPTION
I use Docker for all of my Home Assistant related things. This makes it easy to start the harmony-api project with a Docker container. You may consider setting up your own Docker repo to replace mine. That way it will update any time you push changes.
