### PR TITLE
Multiple Hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Harmony API!!
 
-Harmony API is a simple server allowing you to query/control a local [Harmony
-Home Hub](http://myharmony.com/products/detail/home-hub/) over HTTP or MQTT.
+Harmony API is a simple server allowing you to query/control multiple local [Harmony
+Home Hubs](http://myharmony.com/products/detail/home-hub/) over HTTP or MQTT.
 
 With HTTP, you can simply turn your devices on and off and check their status
 with simple HTTP requests from almost any other project.
 
-With MQTT, you can easily monitor the state of your devices as well as switch
-the current activity of your whole hub. This makes it super easy to integrate
+With MQTT, you can easily monitor the state of your devices as well as set
+the current activity of your hub. This makes it super easy to integrate
 into your existing home automation setup.
 
 
 ## Features
 
+* Control multiple Harmony hubs.
 * List activities.
 * Get current status, including if everything is off, or what the current activity is.
 * Turn everything off.
@@ -24,12 +25,12 @@ into your existing home automation setup.
 
 ## Settings
 
-Harmony API discovers your hub automatically. You can optionally add your MQTT
+Harmony API discovers your hubs automatically. You can optionally add your MQTT
 broker's host to connect to it.
 
 ```json
 {
-  "mqtt_host": "192.168.1.106",
+  "mqtt_host": "mqtt://192.168.1.106",
   "mqtt_options": {
       "port": 1883,
       "username": "someuser",
@@ -52,7 +53,7 @@ variable to use your own port.
 ### Forever
 harmony-api has support for [Forever](https://github.com/foreverjs/forever). It uses
 `launchd` on OS X to kick it off so that it starts on boot. There is no `init.d`
-other Linux support of this type. Pull requests would be welcome for this though.
+or other Linux support of this type. Pull requests would be welcome for this though.
 
 ### Development
 You can simply run it by calling `script/server`. This will run it in development
@@ -85,7 +86,7 @@ Launch the app via `script/server` to run it in the development environment.
 ## MQTT Docs
 
 harmony-api can report its state changes to your MQTT broker. Just edit your
-config file in `config/config.json` to add your MQTT host.
+config file in `config/config.json` to add your MQTT host and options.
 
 By default harmony-api publishes topics with the namespace of: `harmony-api`. This can be overriden
 by setting `topic_namespace` in your config file.
@@ -95,29 +96,32 @@ by setting `topic_namespace` in your config file.
 When the state changes on your harmony hub, state topics will be immediately
 broadcasted over your broker. There's quite a few topics that are broadcasted.
 
+State topics are namespaced by your Harmony hub's name, as a slug. You can rename your hub
+in the Harmony app.
+
 Here's a list:
 
 #### Current State
 
 This topic describes the current power state. Message is `on` or `off`.
 
-`harmony-api/state` `on`
+`harmony-api/hubs/family-room/state` `on`
 
 #### Current Activity
 
 This topic describes what the current activity of the hub is. The message is
 the slug of an activity name.
 
-`harmony-api/current_activity` `watch-tv`
+`harmony-api/hubs/family-room/current_activity` `watch-tv`
 
 #### Activity States
 
 These topics describe the state of each activity that the hub has. The message
 is `on` or `off`. There will a topic for every activity on your hub.
 
-`harmony-api/activities/watch-tv/state` `off`  
-`harmony-api/activities/watch-apple-tv/state` `on`  
-`harmony-api/activities/play-xbox-one/state` `off`  
+`harmony-api/hubs/family-room/activities/watch-tv/state` `off`  
+`harmony-api/hubs/family-room/activities/watch-apple-tv/state` `on`  
+`harmony-api/hubs/family-room/activities/play-xbox-one/state` `off`  
 
 
 ### Command Topics
@@ -126,19 +130,17 @@ You can also command harmony-api to change activities by publishing topics.
 harmony-api listens to this topic and will change to the activity when it sees
 it.
 
-Just provide the slug of the activity you want to switch to and `on` as the
-message. Any use of this topic with the message `off` will turn everything off.
+Just provide the slug of the hub and activity you want to switch to and `on` as
+the message. Any use of this topic with the message `off` will turn everything
+off.
 
 `harmony-api/activities/watch-tv/command` `on`  
 
 
 ## HTTP API Docs
 
-This is a quick overview of the service. Read [app.js](app.js) if you need more
+This is a quick overview of the HTTP service. Read [app.js](app.js) if you need more
 info.
-
-:warning: These endpoints may not be stable as this project moves fast towards
-`1.0.0`.
 
 ### Resources
 
@@ -181,20 +183,15 @@ These are the endpoints you can hit to do things.
 #### Info
   Use these endpoints to query the current state of your Harmony Hub.
 
-    GET /status => StatusResource
-    GET /activities => {:activities => [ActivityResource, ActivityResource, ...]}
+    GET /hubs => {"hubs": ["family-room", "bedroom"] }
+    GET /hubs/:hub_slug/status => StatusResource
+    GET /hubs/:hub_slug/activities => {"activities": [ActivityResource, ActivityResource, ...]}
 
 #### Control
   Use these endpoints to control your devices through your Harmony Hub.
 
-    PUT /off => NowPlayingResource => {message: "ok"}
-    POST /start_activity?activity=watch-tv => {message: "ok"}
-
-## To Do
-
-- [ ] Support multiple Harmony Hubs
-- [ ] Support raw commands to control individual devices
-
+    PUT /hubs/:hub_slug/off => {message: "ok"}
+    POST /hubs/:hub_slug/start_activity?activity=watch-tv => {message: "ok"}
 
 ## Contributions
 

--- a/app.js
+++ b/app.js
@@ -110,17 +110,19 @@ function startProcessing(hubSlug, harmonyClient){
   harmonyHubClients[hubSlug] = harmonyClient
 
   // update the list of activities
-  updateActivities()
+  updateActivities(hubSlug)
   // then do it on the set interval
   clearInterval(harmonyActivityUpdateTimer)
-  harmonyActivityUpdateTimer = setInterval(function(){ updateActivities() }, harmonyActivityUpdateInterval)
+  harmonyActivityUpdateTimer = setInterval(function(){ updateActivities(hubSlug) }, harmonyActivityUpdateInterval)
 
   // update the list of activities on the set interval
   clearInterval(harmonyStateUpdateTimer)
   harmonyStateUpdateTimer = setInterval(function(){ updateState() }, harmonyStateUpdateInterval)
 }
 
-function updateActivities(){
+function updateActivities(hubSlug){
+  harmonyHubClient = harmonyClient(hubSlug)
+
   if (!harmonyHubClient) { return }
   console.log('Updating activities.')
 
@@ -131,7 +133,7 @@ function updateActivities(){
         foundActivities[activity.id] = {id: activity.id, slug: parameterize(activity.label), label:activity.label, isAVActivity: activity.isAVActivity}
       })
 
-      harmonyActivitiesCache = foundActivities
+      harmonyActivitiesCache[hubSlug] = foundActivities
     })
   } catch(err) {
     console.log("ERROR: " + err.message);

--- a/app.js
+++ b/app.js
@@ -186,9 +186,9 @@ function updateState(){
 
 }
 
-function cachedHarmonyActivities(){
-  return Object.keys(harmonyActivitiesCache).map(function(key) {
-    return harmonyActivitiesCache[key]
+function cachedHarmonyActivities(hubSlug){
+  return Object.keys(harmonyActivitiesCache[hubSlug]).map(function(key) {
+    return harmonyActivitiesCache[hubSlug][key]
   })
 }
 
@@ -239,8 +239,8 @@ app.get('/', function(req, res){
   res.sendfile('index.html');
 })
 
-app.get('/activities', function(req, res){
-  res.json({activities: cachedHarmonyActivities()})
+app.get('/:hubSlug/activities', function(req, res){
+  res.json({activities: cachedHarmonyActivities(req.params.hubSlug)})
 })
 
 app.get('/status', function(req, res){

--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ app.use(morgan(logFormat))
 // Middleware
 // Check to make sure we have a harmonyHubClient to connect to
 var hasHarmonyHubClient = function(req, res, next) {
-  if (hasHarmonyHubClient) {
+  if (harmonyHubClient) {
     next()
   }else{
     res.status(500).json({message: "Can not connect to hub."})

--- a/app.js
+++ b/app.js
@@ -72,15 +72,9 @@ discover.on('offline', function(hubInfo) {
   delete(harmonyHubStates[hubSlug])
 })
 
-if (config['hub_ip']) {
-  // Connect to hub:
-  console.log('Connecting to Harmony hub at ' + config['hub_ip'])
-  harmony(config['hub_ip']).then(startProcessing)
-}else{
-  // Look for hubs:
-  console.log('Starting discovery.')
-  discover.start()
-}
+// Look for hubs:
+console.log('Starting discovery.')
+discover.start()
 
 // mqtt api
 

--- a/app.js
+++ b/app.js
@@ -249,21 +249,21 @@ app.get('/hubs', function(req, res){
   res.json({hubs: Object.keys(harmonyHubClients)})
 })
 
-app.get('/hubs/:hubSlug/activities', function(req, res){
+app.get('/:hubSlug/activities', function(req, res){
   res.json({activities: cachedHarmonyActivities(req.params.hubSlug)})
 })
 
-app.get('/hubs/:hubSlug/status', function(req, res){
+app.get('/:hubSlug/status', function(req, res){
   res.json(harmonyHubStates[req.params.hubSlug])
 })
 
-app.put('/hubs/:hubSlug/off', function(req, res){
+app.put('/:hubSlug/off', function(req, res){
   off(req.params.hubSlug)
 
   res.json({message: "ok"})
 })
 
-app.post('/hubs/:hubSlug/start_activity', function(req, res){
+app.post('/:hubSlug/start_activity', function(req, res){
   activity = activityBySlugs(req.params.hubSlug, req.query.activity)
 
   if (activity) {

--- a/app.js
+++ b/app.js
@@ -164,17 +164,17 @@ function updateState(hubSlug){
       harmonyHubStates[hubSlug] = data
 
       if (!previousActivity || (activity.id != previousActivity.id)) {
-        publish(hubSlug + '/' + 'current_activity', activity.slug, {retain: true})
-        publish(hubSlug + '/' + 'state', activity.id == -1 ? 'off' : 'on' , {retain: true})
+        publish('hubs/' + hubSlug + '/' + 'current_activity', activity.slug, {retain: true})
+        publish('hubs/' + hubSlug + '/' + 'state', activity.id == -1 ? 'off' : 'on' , {retain: true})
 
         for (var i = 0; i < cachedHarmonyActivities(hubSlug).length; i++) {
           activities = cachedHarmonyActivities(hubSlug)
           cachedActivity = activities[i]
 
           if (activity == cachedActivity) {
-            publish(hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'on', {retain: true})
+            publish('hubs/' + hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'on', {retain: true})
           }else{
-            publish(hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'off', {retain: true})
+            publish('hubs/' + hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'off', {retain: true})
           }
         }
       }

--- a/app.js
+++ b/app.js
@@ -78,24 +78,25 @@ if (config['hub_ip']) {
 // mqtt api
 
 mqttClient.on('connect', function () {
-  mqttClient.subscribe(TOPIC_NAMESPACE + '/activities/+/command')
+  mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/activities/+/command')
 });
 
 mqttClient.on('message', function (topic, message) {
-  var commandPattern = new RegExp(/activities\/(.*)\/command/);
+  var commandPattern = new RegExp(/hubs\/(.*)\/activities\/(.*)\/command/);
   var commandMatches = topic.match(commandPattern);
 
   if (commandMatches) {
-    var activitySlug = commandMatches[1]
+    var hubSlug = commandMatches[1]
+    var activitySlug = commandMatches[2]
     var state = message.toString()
 
-    activity = activityBySlugs(activitySlug)
+    activity = activityBySlugs(hubSlug, activitySlug)
     if (!activity) { return }
 
     if (state === 'on') {
-      startActivity(activity.id)
+      startActivity(hubSlug, activity.id)
     }else if (state === 'off'){
-      off()
+      off(hubSlug)
     }
   }
 

--- a/app.js
+++ b/app.js
@@ -239,6 +239,10 @@ app.get('/', function(req, res){
   res.sendfile('index.html');
 })
 
+app.get('/hubs', function(req, res){
+  res.json({hubs: Object.keys(harmonyHubClients)})
+})
+
 app.get('/:hubSlug/activities', function(req, res){
   res.json({activities: cachedHarmonyActivities(req.params.hubSlug)})
 })

--- a/app.js
+++ b/app.js
@@ -16,11 +16,11 @@ var harmony = require('harmonyhubjs-client')
 var harmonyHubClients = {}
 var harmonyActivitiesCache = {}
 var harmonyActivityUpdateInterval = 1*60*1000 // 1 minute
-var harmonyActivityUpdateTimer
+var harmonyActivityUpdateTimers = {}
 
 var harmonyState
 var harmonyStateUpdateInterval = 5*1000 // 5 seconds
-var harmonyStateUpdateTimer
+var harmonyStateUpdateTimers = {}
 
 var mqttClient = config.hasOwnProperty("mqtt_options") ?
     mqtt.connect(config.mqtt_host, config.mqtt_options) :
@@ -107,12 +107,12 @@ function startProcessing(hubSlug, harmonyClient){
   // update the list of activities
   updateActivities(hubSlug)
   // then do it on the set interval
-  clearInterval(harmonyActivityUpdateTimer)
-  harmonyActivityUpdateTimer = setInterval(function(){ updateActivities(hubSlug) }, harmonyActivityUpdateInterval)
+  clearInterval(harmonyActivityUpdateTimers[hubSlug])
+  harmonyActivityUpdateTimers[hubSlug] = setInterval(function(){ updateActivities(hubSlug) }, harmonyActivityUpdateInterval)
 
   // update the list of activities on the set interval
-  clearInterval(harmonyStateUpdateTimer)
-  harmonyStateUpdateTimer = setInterval(function(){ updateState() }, harmonyStateUpdateInterval)
+  clearInterval(harmonyStateUpdateTimers[hubSlug])
+  harmonyStateUpdateTimers[hubSlug] = setInterval(function(){ updateState(hubSlug) }, harmonyStateUpdateInterval)
 }
 
 function updateActivities(hubSlug){

--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ var discover = new harmonyHubDiscover(61991)
 
 discover.on('online', function(hubInfo) {
   // Triggered when a new hub was found
-  console.log('Hub discovered ' + hubInfo.ip + '.')
+  console.log('Hub discovered: ' + hubInfo.friendlyName + ' at ' + hubInfo.ip + '.')
 
   if (hubInfo.ip) {
     console.log('Stopping discovery.')
@@ -61,9 +61,9 @@ discover.on('online', function(hubInfo) {
 
 })
 
-discover.on('offline', function(hub) {
+discover.on('offline', function(hubInfo) {
   // Triggered when a hub disappeared
-  console.log('lost hub at: ' + hub.ip)
+  console.log('Hub lost: ' + hubInfo.friendlyName + ' at ' + hubInfo.ip + '.')
 })
 
 if (config['hub_ip']) {

--- a/app.js
+++ b/app.js
@@ -250,7 +250,7 @@ app.get('/hubs', function(req, res){
   res.json({hubs: Object.keys(harmonyHubClients)})
 })
 
-app.get('/:hubSlug/activities', function(req, res){
+app.get('/hubs/:hubSlug/activities', function(req, res){
   hubSlug = req.params.hubSlug
   harmonyHubClient = harmonyHubClients[hubSlug]
 
@@ -261,7 +261,7 @@ app.get('/:hubSlug/activities', function(req, res){
   }
 })
 
-app.get('/:hubSlug/status', function(req, res){
+app.get('/hubs/:hubSlug/status', function(req, res){
   hubSlug = req.params.hubSlug
   harmonyHubClient = harmonyHubClients[hubSlug]
 
@@ -272,7 +272,7 @@ app.get('/:hubSlug/status', function(req, res){
   }
 })
 
-app.put('/:hubSlug/off', function(req, res){
+app.put('/hubs/:hubSlug/off', function(req, res){
   hubSlug = req.params.hubSlug
   harmonyHubClient = harmonyHubClients[hubSlug]
 
@@ -284,7 +284,7 @@ app.put('/:hubSlug/off', function(req, res){
   }
 })
 
-app.post('/:hubSlug/start_activity', function(req, res){
+app.post('/hubs/:hubSlug/start_activity', function(req, res){
   activity = activityBySlugs(req.params.hubSlug, req.query.activity)
 
   if (activity) {
@@ -302,8 +302,8 @@ app.get('/hubs_for_index', function(req, res){
 
   Object.keys(harmonyHubClients).forEach(function(hubSlug) {
     output += '<h3 class="hub-name">' + hubSlug.replace('-', ' ') + '</h3>'
-    output += '<p><span class="method">GET</span> <a href="/' + hubSlug + '/status">/' + hubSlug + '/status</a></p>'
-    output += '<p><span class="method">GET</span> <a href="/' + hubSlug + '/activities">/' + hubSlug + '/activities</a></p>'
+    output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/status">/hubs/' + hubSlug + '/status</a></p>'
+    output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/activities">/hubs/' + hubSlug + '/activities</a></p>'
   });
 
   res.send(output)

--- a/app.js
+++ b/app.js
@@ -63,6 +63,13 @@ discover.on('online', function(hubInfo) {
 discover.on('offline', function(hubInfo) {
   // Triggered when a hub disappeared
   console.log('Hub lost: ' + hubInfo.friendlyName + ' at ' + hubInfo.ip + '.')
+  hubSlug = parameterize(hubInfo.friendlyName)
+
+  clearInterval(harmonyStateUpdateTimers[hubSlug])
+  clearInterval(harmonyActivityUpdateTimers[hubSlug])
+  delete(harmonyHubClients[hubSlug])
+  delete(harmonyActivitiesCache[hubSlug])
+  delete(harmonyHubStates[hubSlug])
 })
 
 if (config['hub_ip']) {

--- a/app.js
+++ b/app.js
@@ -163,17 +163,17 @@ function updateState(hubSlug){
       harmonyHubStates[hubSlug] = data
 
       if (!previousActivity || (activity.id != previousActivity.id)) {
-        // publish('current_activity', activity.slug, {retain: true})
-        // publish('state', activity.id == -1 ? 'off' : 'on' , {retain: true})
+        publish(hubSlug + '/' + 'current_activity', activity.slug, {retain: true})
+        publish(hubSlug + '/' + 'state', activity.id == -1 ? 'off' : 'on' , {retain: true})
 
         for (var i = 0; i < cachedHarmonyActivities(hubSlug).length; i++) {
           activities = cachedHarmonyActivities(hubSlug)
           cachedActivity = activities[i]
 
           if (activity == cachedActivity) {
-            // publish('activities/' + cachedActivity.slug + '/state', 'on', {retain: true})
+            publish(hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'on', {retain: true})
           }else{
-            // publish('activities/' + cachedActivity.slug + '/state', 'off', {retain: true})
+            publish(hubSlug + '/' + 'activities/' + cachedActivity.slug + '/state', 'off', {retain: true})
           }
         }
       }

--- a/app.js
+++ b/app.js
@@ -295,4 +295,17 @@ app.post('/:hubSlug/start_activity', function(req, res){
   }
 })
 
+app.get('/hubs_for_index', function(req, res){
+  hubSlugs = Object.keys(harmonyHubClients)
+  output = ""
+
+  Object.keys(harmonyHubClients).forEach(function(hubSlug) {
+    output += '<h3 class="hub-name">' + hubSlug.replace('-', ' ') + '</h3>'
+    output += '<p><span class="method">GET</span> <a href="/' + hubSlug + '/status">/' + hubSlug + '/status</a></p>'
+    output += '<p><span class="method">GET</span> <a href="/' + hubSlug + '/activities">/' + hubSlug + '/activities</a></p>'
+  });
+
+  res.send(output)
+})
+
 app.listen(process.env.PORT || 8282)

--- a/app.js
+++ b/app.js
@@ -53,9 +53,6 @@ discover.on('online', function(hubInfo) {
   console.log('Hub discovered: ' + hubInfo.friendlyName + ' at ' + hubInfo.ip + '.')
 
   if (hubInfo.ip) {
-    console.log('Stopping discovery.')
-    discover.stop()
-
     harmony(hubInfo.ip).then(startProcessing)
   }
 

--- a/app.js
+++ b/app.js
@@ -250,17 +250,37 @@ app.get('/hubs', function(req, res){
 })
 
 app.get('/:hubSlug/activities', function(req, res){
-  res.json({activities: cachedHarmonyActivities(req.params.hubSlug)})
+  hubSlug = req.params.hubSlug
+  harmonyHubClient = harmonyHubClients[hubSlug]
+
+  if (harmonyHubClient) {
+    res.json({activities: cachedHarmonyActivities(hubSlug)})
+  }else{
+    res.status(404).json({message: "Not Found"})
+  }
 })
 
 app.get('/:hubSlug/status', function(req, res){
-  res.json(harmonyHubStates[req.params.hubSlug])
+  hubSlug = req.params.hubSlug
+  harmonyHubClient = harmonyHubClients[hubSlug]
+
+  if (harmonyHubClient) {
+    res.json(harmonyHubStates[hubSlug])
+  }else{
+    res.status(404).json({message: "Not Found"})
+  }
 })
 
 app.put('/:hubSlug/off', function(req, res){
-  off(req.params.hubSlug)
+  hubSlug = req.params.hubSlug
+  harmonyHubClient = harmonyHubClients[hubSlug]
 
-  res.json({message: "ok"})
+  if (harmonyHubClient) {
+    off(hubSlug)
+    res.json({message: "ok"})
+  }else{
+    res.status(404).json({message: "Not Found"})
+  }
 })
 
 app.post('/:hubSlug/start_activity', function(req, res){

--- a/app.js
+++ b/app.js
@@ -101,11 +101,6 @@ mqttClient.on('message', function (topic, message) {
 
 });
 
-
-function harmonyClient(hubSlug){
-  return harmonyHubClients[hubSlug]
-}
-
 function startProcessing(hubSlug, harmonyClient){
   harmonyHubClients[hubSlug] = harmonyClient
 
@@ -121,7 +116,7 @@ function startProcessing(hubSlug, harmonyClient){
 }
 
 function updateActivities(hubSlug){
-  harmonyHubClient = harmonyClient(hubSlug)
+  harmonyHubClient = harmonyHubClients[hubSlug]
 
   if (!harmonyHubClient) { return }
   console.log('Updating activities.')

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,5 +1,5 @@
 {
-  "mqtt_host": "http://127.0.0.1",
+  "mqtt_host": "mqtt://127.0.0.1",
   "mqtt_options": {
       "port": 1883,
       "username": "someuser",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "^4.12.4",
     "morgan": "^1.6.1",
     "body-parser": "^1.12.4",
-    "harmonyhubjs-client": "^1.1.8",
+    "harmonyhubjs-client": "maddox/harmonyhubjs-client#for-harmony-api",
     "harmonyhubjs-discover": "^1.0.2",
     "parameterize": "^0.0.7",
     "mqtt": "^1.4.1"

--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,12 @@
       a:hover { text-decoration: underline; }
       .logo { display: block; margin: auto }
       .content { margin: 20px 25%; }
-      .docs { background-color: #f4f4f4; border-radius: 4px; padding: 10px;}
+      .docs { background-color: #f4f4f4; border-radius: 4px; padding: 10px; margin-bottom: 20px;}
       .docs p { padding: 0; margin: 0; line-height: 28px; font-size: 14px; font-family: Consolas, 'Liberation Mono', Menlo, Courier, monospace; }
       .docs .method { background-color: #dbdbdb; padding: 4px; border-radius: 2px; margin-right: 4px;}
       .docs h2 { margin-bottom: 8px;}
       .docs h2:first-child { margin-top: 0;}
+      .docs h3.hub-name { text-transform: capitalize;}
       .footer { text-align: center; font-size: 12px; margin: 10px 0 50px 0;}
     </style>
   </head>
@@ -26,12 +27,20 @@
       <div class="docs">
         <h2>Info</h2>
         <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
-        <p><span class="method">GET</span> <a href="/status">/status</a></p>
-        <p><span class="method">GET</span> <a href="/activities">/activities</a></p>
+        <p><span class="method">GET</span> <a href="/:hub_slug/status">/:hub_slug/status</a></p>
+        <p><span class="method">GET</span> <a href="/:hub_slug/activities">/:hub_slug/activities</a></p>
+      </div>
 
+      <div class="docs">
         <h2>Control</h2>
         <p><span class="method">PUT</span> /off</p>
         <p><span class="method">POST</span> /start_activity?activity=watch-tv</p>
+      </div>
+
+      <div class="docs">
+        <h2>Your Hubs</h2>
+        <div id="your-hubs">
+        </div>
       </div>
 
       <div class="footer">
@@ -39,5 +48,25 @@
       </div>
     </div>
 
+    <script>
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', '/hubs_for_index');
+    xhr.send(null);
+
+    xhr.onreadystatechange = function () {
+      var DONE = 4; // readyState 4 means the request is done.
+      var OK = 200; // status 200 is a successful return.
+      if (xhr.readyState === DONE) {
+        if (xhr.status === OK) {
+          var div = document.createElement("div")
+          div.innerHTML = xhr.responseText
+          document.getElementById("your-hubs").appendChild(div)
+        } else {
+          console.log('Error: ' + xhr.status); // An error occurred during the request.
+        }
+      }
+    }
+
+    </script>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -27,8 +27,8 @@
       <div class="docs">
         <h2>Info</h2>
         <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
-        <p><span class="method">GET</span> <a href="/:hub_slug/status">/:hub_slug/status</a></p>
-        <p><span class="method">GET</span> <a href="/:hub_slug/activities">/:hub_slug/activities</a></p>
+        <p><span class="method">GET</span> /:hub_slug/status</p>
+        <p><span class="method">GET</span> /:hub_slug/activities</p>
       </div>
 
       <div class="docs">

--- a/public/index.html
+++ b/public/index.html
@@ -33,8 +33,8 @@
 
       <div class="docs">
         <h2>Control</h2>
-        <p><span class="method">PUT</span> /off</p>
-        <p><span class="method">POST</span> /start_activity?activity=watch-tv</p>
+        <p><span class="method">PUT</span> /:hub_slug/off</p>
+        <p><span class="method">POST</span> /:hub_slug/start_activity?activity=watch-tv</p>
       </div>
 
       <div class="docs">

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,7 @@
 
       <div class="docs">
         <h2>Info</h2>
+        <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
         <p><span class="method">GET</span> <a href="/status">/status</a></p>
         <p><span class="method">GET</span> <a href="/activities">/activities</a></p>
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,14 +27,14 @@
       <div class="docs">
         <h2>Info</h2>
         <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
-        <p><span class="method">GET</span> /:hub_slug/status</p>
-        <p><span class="method">GET</span> /:hub_slug/activities</p>
+        <p><span class="method">GET</span> /hubs/:hub_slug/status</p>
+        <p><span class="method">GET</span> /hubs/:hub_slug/activities</p>
       </div>
 
       <div class="docs">
         <h2>Control</h2>
-        <p><span class="method">PUT</span> /:hub_slug/off</p>
-        <p><span class="method">POST</span> /:hub_slug/start_activity?activity=watch-tv</p>
+        <p><span class="method">PUT</span> /hubs/:hub_slug/off</p>
+        <p><span class="method">POST</span> /hubs/:hub_slug/start_activity?activity=watch-tv</p>
       </div>
 
       <div class="docs">


### PR DESCRIPTION
This introduces support for multiple harmony hubs. 

To support multiple hubs, the entire API has changed. Both MQTT topics and HTTP endpoints are now namespaces with `/hubs/:hub_slug/` to accommodate commands and state querying of each hub on your network.

Endpoints and topics are still namespaced, even if you only have a single hub.

For more info on the changes, [read the README](/maddox/harmony-api/blob/multiple-hubs/README.md) on this branch.
