### PR TITLE
Copy sample config so service starts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY package.json /usr/src/app
 RUN npm install
 
 COPY . /usr/src/app
+COPY ./config/config.sample.json /config/config.json
 
 ENV CONFIG_DIR /config
 


### PR DESCRIPTION
There's an issue where the service will error when the config.json isn't found. This copys the sample so the service starts and gives the user something to start with editing.
