### PR TITLE
Manually specify hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,20 @@ Installation with Docker is straightforward. Adjust the following command so tha
         -p 8282:8282 -d jonmaddox/harmony-api
 
 This will launch Harmony API and serve the web interface from port 8282 on your Docker host. Hub
-discovery requires host networking (`--net=host`). However, you can specify your Harmony Hub IP
-address in `config.json` as `hub_ip`.
+discovery requires host networking (`--net=host`). However, you can specify your Harmony Hubs in
+`config.json` e.g.:
+```json
+  "hubs": [
+    {
+      "name": "Living Room",
+      "ip": "192.168.1.111"
+    },
+    {
+      "name": "Bedroom",
+      "ip": "192.168.1.112"
+    },
+  ]
+```
 
 ## Logging
 

--- a/app.js
+++ b/app.js
@@ -72,9 +72,17 @@ discover.on('offline', function(hubInfo) {
   delete(harmonyHubStates[hubSlug])
 })
 
-// Look for hubs:
-console.log('Starting discovery.')
-discover.start()
+if (config.hasOwnProperty("hubs") && Array.isArray(config.hubs)) {
+  config.hubs.forEach(function(hub) {
+    harmony(hub.ip).then(function(client){
+      startProcessing(parameterize(hub.name), client)
+    })
+  })
+} else {
+  // Look for hubs:
+  console.log('Starting discovery.')
+  discover.start()
+}
 
 // mqtt api
 


### PR DESCRIPTION
The changes for multiple hubs removed the ability to manually specify hubs. This adds it back in.
