### PR TITLE
Add support for device commands

### DIFF
--- a/app.js
+++ b/app.js
@@ -359,10 +359,10 @@ app.get('/hubs/:hubSlug/devices', function(req, res){
   harmonyHubClient = harmonyHubClients[hubSlug]
 
   if (harmonyHubClient) {
-    var deviceSlugs = cachedHarmonyDevices(hubSlug).map(function(device) {
-      return device.slug
+    var devices = cachedHarmonyDevices(hubSlug).map(function(device) {
+      return {id:device.id, slug:device.slug, label:device.label}
     })
-    res.json({devices: deviceSlugs})
+    res.json({devices: devices})
   }else{
     res.status(404).json({message: "Not Found"})
   }
@@ -374,7 +374,11 @@ app.get('/hubs/:hubSlug/devices/:deviceSlug/commands', function(req, res){
   device = deviceBySlugs(hubSlug, deviceSlug)
 
   if (device) {
-    res.json({commands: Object.keys(device.commands)})
+    commands =  Object.keys(device.commands).map(function(commandSlug){
+      cmd = device.commands[commandSlug]
+      return {name:cmd.name, slug:commandSlug, label:cmd.label}
+    })
+    res.json({commands: commands})
   }else{
     res.status(404).json({message: "Not Found"})
   }

--- a/app.js
+++ b/app.js
@@ -84,15 +84,18 @@ discover.start()
 
 mqttClient.on('connect', function () {
   mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/activities/+/command')
+  mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/devices/+/command')
 });
 
 mqttClient.on('message', function (topic, message) {
-  var commandPattern = new RegExp(/hubs\/(.*)\/activities\/(.*)\/command/);
-  var commandMatches = topic.match(commandPattern);
+  var activityCommandPattern = new RegExp(/hubs\/(.*)\/activities\/(.*)\/command/);
+  var deviceCommandPattern = new RegExp(/hubs\/(.*)\/devices\/(.*)\/command/);
+  var activityCommandMatches = topic.match(activityCommandPattern);
+  var deviceCommandMatches = topic.match(deviceCommandPattern);
 
-  if (commandMatches) {
-    var hubSlug = commandMatches[1]
-    var activitySlug = commandMatches[2]
+  if (activityCommandMatches) {
+    var hubSlug = activityCommandMatches[1]
+    var activitySlug = activityCommandMatches[2]
     var state = message.toString()
 
     activity = activityBySlugs(hubSlug, activitySlug)
@@ -103,6 +106,15 @@ mqttClient.on('message', function (topic, message) {
     }else if (state === 'off'){
       off(hubSlug)
     }
+  } else if (deviceCommandMatches) {
+    var hubSlug = deviceCommandMatches[1]
+    var deviceSlug = deviceCommandMatches[2]
+    var command = message.toString()
+
+    command = commandBySlugs(hubSlug, deviceSlug, command)
+    if (!command) { return }
+
+    sendAction(hubSlug, command.action)
   }
 
 });

--- a/app.js
+++ b/app.js
@@ -359,10 +359,10 @@ app.get('/hubs/:hubSlug/devices', function(req, res){
   harmonyHubClient = harmonyHubClients[hubSlug]
 
   if (harmonyHubClient) {
-    var devices = [];
-    res.json({devices: cachedHarmonyDevices(hubSlug).map(function(device) {
+    var deviceSlugs = cachedHarmonyDevices(hubSlug).map(function(device) {
       return device.slug
-    })})
+    })
+    res.json({devices: deviceSlugs})
   }else{
     res.status(404).json({message: "Not Found"})
   }

--- a/app.js
+++ b/app.js
@@ -307,6 +307,20 @@ app.get('/hubs/:hubSlug/activities', function(req, res){
   }
 })
 
+app.get('/hubs/:hubSlug/devices', function(req, res){
+  hubSlug = req.params.hubSlug
+  harmonyHubClient = harmonyHubClients[hubSlug]
+
+  if (harmonyHubClient) {
+    var devices = [];
+    res.json({devices: cachedHarmonyDevices(hubSlug).map(function(device) {
+      return device.slug
+    })})
+  }else{
+    res.status(404).json({message: "Not Found"})
+  }
+})
+
 app.get('/hubs/:hubSlug/status', function(req, res){
   hubSlug = req.params.hubSlug
   harmonyHubClient = harmonyHubClients[hubSlug]
@@ -350,6 +364,7 @@ app.get('/hubs_for_index', function(req, res){
     output += '<h3 class="hub-name">' + hubSlug.replace('-', ' ') + '</h3>'
     output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/status">/hubs/' + hubSlug + '/status</a></p>'
     output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/activities">/hubs/' + hubSlug + '/activities</a></p>'
+    output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/devices">/hubs/' + hubSlug + '/devices</a></p>'
   });
 
   res.send(output)

--- a/app.js
+++ b/app.js
@@ -218,13 +218,6 @@ function updateDevices(hubSlug){
       harmonyDevicesCache[hubSlug] = foundDevices
     })
 
-    for (var i = 0; i < cachedHarmonyDevices(hubSlug).length; i++) {
-      devices = cachedHarmonyDevices(hubSlug)
-      cachedDevice = devices[i]
-      actions = Object.keys(cachedDevice.commands)
-
-      publish('hubs/' + hubSlug + '/' + 'devices/' + cachedDevice.slug + '/actions', JSON.stringify(actions), {retain: true})
-    }
   } catch(err) {
     console.log("Devices ERROR: " + err.message);
   }

--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,8 @@
         <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
         <p><span class="method">GET</span> /hubs/:hub_slug/status</p>
         <p><span class="method">GET</span> /hubs/:hub_slug/activities</p>
+        <p><span class="method">GET</span> /hubs/:hub_slug/devices</p>
+        <p><span class="method">GET</span> /hubs/:hub_slug/devices/:device_slug/commands</p>
       </div>
 
       <div class="docs">

--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,7 @@
         <h2>Control</h2>
         <p><span class="method">PUT</span> /hubs/:hub_slug/off</p>
         <p><span class="method">POST</span> /hubs/:hub_slug/start_activity?activity=watch-tv</p>
+        <p><span class="method">POST</span> /hubs/:hub_slug/devices/:device_slug/activate_command?command=power-on</p>
       </div>
 
       <div class="docs">


### PR DESCRIPTION
I added in the ability to query devices and their commands to the HTTP API. You can send the commands with the HTTP API or MQTT.

I stuck strictly to the design of the existing routes for this PR. I figure if we decide we want to change the layout, we can do that in another PR.

This fixes #26.
