### PR TITLE
Replacing /usr/local/bin/forever with /usr/bin/env forever for better portability of script/server

### DIFF
--- a/script/server
+++ b/script/server
@@ -6,7 +6,7 @@ test -z "$NODE_ENV" &&
   export NODE_ENV='development'
 
 if [ "$NODE_ENV" = "development" ]; then
-  /usr/local/bin/forever -f config/forever/development.json
+  /usr/bin/env forever -f config/forever/development.json
 else
-  /usr/local/bin/forever start config/forever/production.json
+  /usr/bin/env forever start config/forever/production.json
 fi


### PR DESCRIPTION
For whatever reason on my system, `forever` is installed in `/usr/bin/forever` and not `/usr/local/bin/forever`. I hope this is a small and acceptable edit that will make `harmony-api` run easily for more users.