### PR TITLE
Make current_activity commands to be hub commands. And make them queryable.

### DIFF
--- a/app.js
+++ b/app.js
@@ -533,6 +533,7 @@ app.get('/hubs_for_index', function(req, res){
     output += '<h3 class="hub-name">' + hubSlug.replace('-', ' ') + '</h3>'
     output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/status">/hubs/' + hubSlug + '/status</a></p>'
     output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/activities">/hubs/' + hubSlug + '/activities</a></p>'
+    output += '<p><span class="method">GET</span> <a href="/hubs/' + hubSlug + '/commands">/hubs/' + hubSlug + '/commands</a></p>'
     cachedHarmonyActivities(hubSlug).forEach(function(activity) {
       path = '/hubs/' + hubSlug + '/activities/' + activity.slug + '/commands'
       output += '<p><span class="method">GET</span> <a href="' + path + '">' + path + '</a></p>'

--- a/app.js
+++ b/app.js
@@ -303,6 +303,16 @@ function activityBySlugs(hubSlug, activitySlug){
   return activity
 }
 
+function activityCommandsBySlugs(hubSlug, activitySlug){
+  activity = activityBySlugs(req.params.hubSlug, req.params.activitySlug)
+
+  if (activity) {
+    return Object.keys(activity.commands).map(function(commandSlug){
+      return activity.commands[commandSlug]
+    })
+  }
+}
+
 function cachedHarmonyDevices(hubSlug){
   devices = harmonyDevicesCache[hubSlug]
   if (!devices) { return [] }
@@ -396,12 +406,9 @@ app.get('/hubs/:hubSlug/activities', function(req, res){
 app.get('/hubs/:hubSlug/activities/:activitySlug/commands', function(req, res){
   hubSlug = req.params.hubSlug
   activitySlug = req.params.activitySlug
-  activity = activityBySlugs(req.params.hubSlug, req.params.activitySlug)
+  commands = activityCommandsBySlugs(req.params.hubSlug, req.params.activitySlug);
 
-  if (activity) {
-    commands = Object.keys(activity.commands).map(function(commandSlug){
-      return activity.commands[commandSlug]
-    })
+  if (commands) {
     res.json({commands: commands})
   }else{
     res.status(404).json({message: "Not Found"})
@@ -449,11 +456,8 @@ app.get('/hubs/:hubSlug/commands', function(req, res){
   hubSlug = req.params.hubSlug
   activitySlug = harmonyHubStates[hubSlug].current_activity.slug
 
-  activity = activityBySlugs(hubSlug, activitySlug)
-  if (activity) {
-    commands = Object.keys(activity.commands).map(function(commandSlug){
-      return activity.commands[commandSlug]
-    })
+  commands = activityCommandsBySlugs(hubSlug, activitySlug);
+  if (commands) {
     res.json({commands: commands})
   }else{
     res.status(404).json({message: "Not Found"})

--- a/app.js
+++ b/app.js
@@ -85,13 +85,13 @@ discover.start()
 mqttClient.on('connect', function () {
   mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/activities/+/command')
   mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/devices/+/command')
-  mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/current_activity/command')
+  mqttClient.subscribe(TOPIC_NAMESPACE + '/hubs/+/command')
 });
 
 mqttClient.on('message', function (topic, message) {
   var activityCommandPattern = new RegExp(/hubs\/(.*)\/activities\/(.*)\/command/);
   var deviceCommandPattern = new RegExp(/hubs\/(.*)\/devices\/(.*)\/command/);
-  var currentActivityCommandPattern = new RegExp(/hubs\/(.*)\/current_activity\/command/);
+  var currentActivityCommandPattern = new RegExp(/hubs\/(.*)\/command/);
   var activityCommandMatches = topic.match(activityCommandPattern);
   var deviceCommandMatches = topic.match(deviceCommandPattern);
   var currentActivityCommandMatches = topic.match(currentActivityCommandPattern);
@@ -445,7 +445,22 @@ app.get('/hubs/:hubSlug/status', function(req, res){
   }
 })
 
-app.post('/hubs/:hubSlug/current_activity/:commandSlug', function(req, res){
+app.get('/hubs/:hubSlug/commands', function(req, res){
+  hubSlug = req.params.hubSlug
+  activitySlug = harmonyHubStates[hubSlug].current_activity.slug
+
+  activity = activityBySlugs(hubSlug, activitySlug)
+  if (activity) {
+    commands = Object.keys(activity.commands).map(function(commandSlug){
+      return activity.commands[commandSlug]
+    })
+    res.json({commands: commands})
+  }else{
+    res.status(404).json({message: "Not Found"})
+  }
+})
+
+app.post('/hubs/:hubSlug/commands/:commandSlug', function(req, res){
   hubSlug = req.params.hubSlug
   activitySlug = harmonyHubStates[hubSlug].current_activity.slug
   var commandSlug = req.params.commandSlug

--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,7 @@
         <h2>Info</h2>
         <p><span class="method">GET</span> <a href="/hubs">/hubs</a></p>
         <p><span class="method">GET</span> /hubs/:hub_slug/status</p>
+        <p><span class="method">GET</span> /hubs/:hub_slug/commands</p>
         <p><span class="method">GET</span> /hubs/:hub_slug/activities</p>
         <p><span class="method">GET</span> /hubs/:hub_slug/activities/:activity_slug/commands</p>
         <p><span class="method">GET</span> /hubs/:hub_slug/devices</p>
@@ -38,7 +39,7 @@
         <h2>Control</h2>
         <p><span class="method">PUT</span> /hubs/:hub_slug/off</p>
         <p><span class="method">POST</span> /hubs/:hub_slug/activities/:activity_slug</p>
-        <p><span class="method">POST</span> /hubs/:hub_slug/current_activity/:command_slug</p>
+        <p><span class="method">POST</span> /hubs/:hub_slug/:command_slug</p>
         <p><span class="method">POST</span> <span class="method">DEPRECATED</span> /hubs/:hub_slug/start_activity?activity=:activity_slug</p>
         <p><span class="method">POST</span> /hubs/:hub_slug/devices/:device_slug/commands/:command_slug</p>
       </div>


### PR DESCRIPTION
I think it make sense to POST to /hubs/:hubSlug/commands/:commandSlug rather than to POST to /hubs/:hubSlug/current_activity/:commandSlug.

Also I think these current activity commands should be queryable.