### PR TITLE
add support for mutiple commands in mqtt message

### DIFF
--- a/app.js
+++ b/app.js
@@ -113,14 +113,17 @@ mqttClient.on('message', function (topic, message) {
   } else if (deviceCommandMatches) {
     var hubSlug = deviceCommandMatches[1]
     var deviceSlug = deviceCommandMatches[2]
-    var messageComponents = message.toString().split(':')
-    var command = messageComponents[0]
-    var repeat = messageComponents[1]
+    var messages = message.toString().split(' ');
+    for (var index = 0; index < messages.length; index++) {
+      var messageComponents = messages[index].toString().split(':')
+      var command = messageComponents[0]
+      var repeat = messageComponents[1]
 
-    command = commandBySlugs(hubSlug, deviceSlug, command)
-    if (!command) { return }
+      command = commandBySlugs(hubSlug, deviceSlug, command)
+      if (!command) { return }
 
-    sendAction(hubSlug, command.action, repeat)
+      sendAction(hubSlug, command.action, repeat)
+    }
   } else if (currentActivityCommandMatches) {
     var hubSlug = currentActivityCommandMatches[1]
     var messageComponents = message.toString().split(':')


### PR DESCRIPTION
harmony-api is a great project.  I use mqtt to glue together a lot
of different home automation pieces and it let me quickly add the
ability to connect/issue commands to my tv setup.

I'm current working on Amazon Alexa control for some additional
features (set channel, volume up/down, mute etc.) that don't 
seem to be built in with the existing logitech/alexa integration.  The 
project is https://github.com/mhdawson/AlexaMqttBridge (still a work in 
progress so no README.md etc. yet).

Along similar lines to the existing support to be able repeat a command
multiple times, this adds the ability to specify multiple commands in a
single mqtt message. This allows me to create a single mqtt message
from Alexa that changes the TV to a particular channel. For example, by
posting "1 7" on the appropriate mqtt topic the commands for 1 and
7 are sent, changing the channel to 17.  

It looks like there are no spaces in the slugs (at least for my devices)
so using spaces to separate the commands seemed safe.  If you 
think there is a better choice, just let me know and I'll update it.
