### PR TITLE
Disable http server (config-option)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ allowed host and options values.
 ## Running It
 Get up and running immediately with `script/server`.
 
+#### Note: 
+On some distros, you might get an error when running it:
+`/usr/bin/node: No such file or directory`
+
+That can probably be fixed by creating a symlink:
+``sudo ln -s `which nodejs` /usr/bin/node``
+
 Harmony API will run on port `8282` by default. Use the `PORT` environment
 variable to use your own port.
 

--- a/app.js
+++ b/app.js
@@ -31,6 +31,9 @@ var mqttClient = config.hasOwnProperty("mqtt_options") ?
     mqtt.connect(config.mqtt_host);
 var TOPIC_NAMESPACE = config.topic_namespace || "harmony-api";
 
+var enableHTTPserver = config.hasOwnProperty("enableHTTPserver") ?
+    config.enableHTTPserver : true;
+
 var app = express()
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(express.static(path.join(__dirname, 'public')));
@@ -560,4 +563,6 @@ app.get('/hubs_for_index', function(req, res){
   res.send(output)
 })
 
-app.listen(process.env.PORT || 8282)
+if (enableHTTPserver) {
+    app.listen(process.env.PORT || 8282)
+}

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,5 +1,7 @@
 {
+  "enableHTTPserver": true,
   "mqtt_host": "mqtt://127.0.0.1",
+  "topic_namespace": "harmony-api",
   "mqtt_options": {
       "port": 1883,
       "username": "someuser",


### PR DESCRIPTION
If you just want to use MQTT and not HTTP, there should be an configurable option of disabling HTTP (for added security).