### PR TITLE
Add Request Header Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ broker's host to connect to it.
 `mqtt_options` is optional, see the [mqtt](https://github.com/mqttjs/MQTT.js#connect) project for
 allowed host and options values.
 
+### Authorization
+
+The optional `authentication_code` configuration element can be used to require the presence of a HTTP header named "auth_code" with a matching value.
+
+```json
+{
+  "authentication_code": "asdf1234"
+}
+```
+
+The header could be added via `curl`: `curl -H "auth_code:asdf1234" localhost:8282:/hubs`, for example.
+
 ## Running It
 Get up and running immediately with `script/server`.
 

--- a/app.js
+++ b/app.js
@@ -42,6 +42,22 @@ var logFormat = "'[:date[iso]] - :remote-addr - :method :url :status :response-t
 app.use(morgan(logFormat))
 
 // Middleware
+//Perform request authentication if configured.
+var headerAuthentication = function(req, res, next) {
+
+  //Move on if header-auth is not specified in the config.
+  if (! config.hasOwnProperty("authentication_code") ) {
+    next();
+  } else if (! req.headers.auth_code ) {
+    return res.status(500).json({ message: "Header authentication configured but no code supplied in request." });
+  } else if ( req.headers.auth_code != config.authentication_code) {
+    return res.status(500).json({ message: "Header authentication failed." });
+  }else{
+    next();
+  }
+}
+app.use(headerAuthentication)
+
 // Check to make sure we have a harmonyHubClient to connect to
 var hasHarmonyHubClient = function(req, res, next) {
   if (Object.keys(harmonyHubClients).length > 0) {
@@ -51,7 +67,6 @@ var hasHarmonyHubClient = function(req, res, next) {
   }
 }
 app.use(hasHarmonyHubClient)
-
 
 var discover = new harmonyHubDiscover(61991)
 

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -1,5 +1,6 @@
 {
   "enableHTTPserver": true,
+  "authentication_code": "asdf1234",
   "mqtt_host": "mqtt://127.0.0.1",
   "topic_namespace": "harmony-api",
   "mqtt_options": {


### PR DESCRIPTION
Implements a middleware handler to check the request header for a "auth_code" value to match the configured "authentication_code" in config.json (optional).