### PR TITLE
Use NPM version of harmonyhubjs-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "^4.12.4",
     "morgan": "^1.6.1",
     "body-parser": "^1.12.4",
-    "harmonyhubjs-client": "maddox/harmonyhubjs-client#for-harmony-api",
+    "harmonyhubjs-client": "^1.1.0",
     "harmonyhubjs-discover": "^1.0.2",
     "parameterize": "^0.0.7",
     "mqtt": "^1.4.1"


### PR DESCRIPTION
This gets us off my fork of `harmonyhubjs-client`.

Fixes #93